### PR TITLE
Fix default printer selection and rename profile to 50 nozzle

### DIFF
--- a/resources/profiles/Cosmos3D.json
+++ b/resources/profiles/Cosmos3D.json
@@ -15,8 +15,8 @@
             "sub_path": "process/fdm_process_common.json"
         },
 		{
-             "name": "Concrete Printing @Cosmos3D X1 60 nozzle",
-             "sub_path": "process/Concrete Printing @Cosmos3D X1 60 nozzle.json"
+             "name": "Concrete Printing @Cosmos3D X1 50 nozzle",
+             "sub_path": "process/Concrete Printing @Cosmos3D X1 50 nozzle.json"
         }
     ],
     "filament_list": [
@@ -39,8 +39,8 @@
             "sub_path": "machine/fdm_machine_common.json"
         },
         {     
-	        "name": "Cosmos3D X1 60 nozzle",
-            "sub_path": "machine/Cosmos3D X1 60 nozzle.json"
+	        "name": "Cosmos3D X1 50 nozzle",
+            "sub_path": "machine/Cosmos3D X1 50 nozzle.json"
         }
     ]
 }

--- a/resources/profiles/Cosmos3D/filament/Generic Concrete.json
+++ b/resources/profiles/Cosmos3D/filament/Generic Concrete.json
@@ -18,6 +18,6 @@
         "8"
     ],
 	"compatible_printers": [
-        "Cosmos3D X1 60 nozzle"
+        "Cosmos3D X1 50 nozzle"
     ]
 }

--- a/resources/profiles/Cosmos3D/machine/Cosmos3D X1 50 nozzle.json
+++ b/resources/profiles/Cosmos3D/machine/Cosmos3D X1 50 nozzle.json
@@ -1,16 +1,16 @@
 {
   "type": "machine",
-  "name": "Cosmos3D X1 60 nozzle",
+  "name": "Cosmos3D X1 50 nozzle",
   "from": "system",
   "setting_id": "GM001",
   "instantiation": "true",
   "nozzle_diameter": ["50"],
   "printer_model": "Cosmos3D X1",
-  "printer_variant": "60",
+  "printer_variant": "50",
   "gcode_flavor": "marlin",
   "inherits": "fdm_machine_common",
   "printable_area": ["0x0", "5000x0", "5000x10000", "0x10000"],
   "printable_height": "3000",
   "default_filament_profile": ["Generic Concrete"],
-  "default_print_profile": "Concrete Printing @Cosmos3D X1 60 nozzle"
+  "default_print_profile": "Concrete Printing @Cosmos3D X1 50 nozzle"
 }

--- a/resources/profiles/Cosmos3D/machine/Cosmos3D X1.json
+++ b/resources/profiles/Cosmos3D/machine/Cosmos3D X1.json
@@ -1,7 +1,7 @@
 {
     "type": "machine_model",
     "name": "Cosmos3D X1",
-    "model_id": "Cosmos3D_X1",
+    "model_id": "Cosmos3D X1",
     "nozzle_diameter": "50",
     "machine_tech": "FFF",
     "family": "Cosmos3D",

--- a/resources/profiles/Cosmos3D/machine/fdm_machine_common.json
+++ b/resources/profiles/Cosmos3D/machine/fdm_machine_common.json
@@ -114,7 +114,7 @@
         "1"
     ],
     "z_hop_types": "Normal Lift",
-    "default_print_profile": "50mm Standard @Cosmos3D X1 60 nozzle",
+    "default_print_profile": "50mm Standard @Cosmos3D X1 50 nozzle",
     "machine_start_gcode": "COSMOS",
     "machine_end_gcode": "N3960 END: G91 G1 X100 Z20\nN3970\nN3980 REPEAT BEGIN END P=50\nN3990\nN4000 CT Y-80\nN4010 M5\nN4020 M30",
     "before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\nG92 E0\n;[layer_z]\n\n"

--- a/resources/profiles/Cosmos3D/process/Concrete Printing @Cosmos3D X1 50 nozzle.json
+++ b/resources/profiles/Cosmos3D/process/Concrete Printing @Cosmos3D X1 50 nozzle.json
@@ -1,7 +1,7 @@
 {
   "type": "process",
   "inherits": "fdm_process_common",
-  "name": "Concrete Printing @Cosmos3D X1 60 nozzle",
+  "name": "Concrete Printing @Cosmos3D X1 50 nozzle",
   "instantiation": "true",
   "adaptive_layer_height": "0",
   "reduce_crossing_wall": "0",
@@ -108,6 +108,6 @@
   "seam_slope_inner_walls": "1",
   "scarf_joint_speed": "100%",
   "scarf_joint_flow_ratio": "1",
-  "compatible_printers": ["Cosmos3D X1 60 nozzle"],
+  "compatible_printers": ["Cosmos3D X1 50 nozzle"],
   "post_process": ""
 }

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -46,7 +46,7 @@ static std::vector<std::string> s_project_options {
 //Orca: add custom as default
 const char *PresetBundle::ORCA_DEFAULT_BUNDLE = "Cosmos3D";
 const char *PresetBundle::ORCA_DEFAULT_PRINTER_MODEL = "Cosmos3D X1";
-const char *PresetBundle::ORCA_DEFAULT_PRINTER_VARIANT = "60";
+const char *PresetBundle::ORCA_DEFAULT_PRINTER_VARIANT = "50";
 const char *PresetBundle::ORCA_DEFAULT_FILAMENT = "Generic Concrete";
 const char *PresetBundle::ORCA_FILAMENT_LIBRARY = "OrcaFilamentLibrary";
 

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -45,8 +45,8 @@ static std::vector<std::string> s_project_options {
 
 //Orca: add custom as default
 const char *PresetBundle::ORCA_DEFAULT_BUNDLE = "Cosmos3D";
-const char *PresetBundle::ORCA_DEFAULT_PRINTER_MODEL = "Cosmos3D X1 60 nozzle";
-const char *PresetBundle::ORCA_DEFAULT_PRINTER_VARIANT = "50";
+const char *PresetBundle::ORCA_DEFAULT_PRINTER_MODEL = "Cosmos3D X1";
+const char *PresetBundle::ORCA_DEFAULT_PRINTER_VARIANT = "60";
 const char *PresetBundle::ORCA_DEFAULT_FILAMENT = "Generic Concrete";
 const char *PresetBundle::ORCA_FILAMENT_LIBRARY = "OrcaFilamentLibrary";
 


### PR DESCRIPTION
## Summary

Fix Cosmos3D printer not being selected as default on fresh install.

### Root cause
Two bugs in `PresetBundle.cpp`:
1. `ORCA_DEFAULT_PRINTER_MODEL` was `"Cosmos3D X1 60 nozzle"` (preset name) instead of `"Cosmos3D X1"` (printer_model field) — `find_system_preset_by_model_and_variant()` never matched
2. `ORCA_DEFAULT_PRINTER_VARIANT` was `"50"` but `printer_variant` was `"60"` — variant comparison also failed

### Fix
- Set `ORCA_DEFAULT_PRINTER_MODEL = "Cosmos3D X1"` and `ORCA_DEFAULT_PRINTER_VARIANT = "50"`
- Rename all profile references from "60 nozzle" to "50 nozzle" to match actual nozzle diameter
- Rename JSON files: `Cosmos3D X1 60 nozzle.json` → `Cosmos3D X1 50 nozzle.json`
- Update `printer_variant` from `"60"` to `"50"`
- Fix `model_id` from `"Cosmos3D_X1"` to `"Cosmos3D X1"` for consistency

### Verified matching chain

| Check point | Looking for | Machine JSON | Match |
|---|---|---|---|
| Bundle load model | `"Cosmos3D X1"` | `printer_model: "Cosmos3D X1"` | ✅ |
| Bundle load variant | `"50"` | `printer_variant: "50"` | ✅ |
| Model variant registration | `nozzle_diameter: "50"` | variant `"50"` | ✅ |
| Default selection model | `"Cosmos3D X1"` | `printer_model: "Cosmos3D X1"` | ✅ |
| Default selection variant | `"50"` | `printer_variant: "50"` | ✅ |

## Test plan

- [ ] Delete `%APPDATA%\OrcaSlicer` or `%APPDATA%\Cosmos3D`
- [ ] Fresh install and launch — skip or cancel wizard
- [ ] App shows Cosmos3D X1 with 5000x10000mm build plate
- [ ] Material defaults to Generic Concrete
- [ ] Process defaults to Concrete Printing @Cosmos3D X1 50 nozzle
- [ ] Nozzle shows 50mm

🤖 Generated with [Claude Code](https://claude.com/claude-code)