### PR TITLE
Fix wizard reopening every launch and printer not persisting

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6303,6 +6303,7 @@ bool GUI_App::run_wizard(ConfigWizard::RunReason reason, ConfigWizard::StartPage
         load_current_presets();
         update_publish_status();
         mainframe->refresh_plugin_tips();
+        app_config->save();
         // BBS: remove SLA related message
     }
 

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -871,6 +871,7 @@ bool GuideFrame::run()
 
         app.app_config->set_legacy_datadir(false);
         app.update_mode();
+        app.app_config->save();
         // BBS
         //app.obj_manipul()->update_ui_from_settings();
         BOOST_LOG_TRIVIAL(info) << "GuideFrame applied";


### PR DESCRIPTION
## Summary

Fix two related bugs: the setup wizard opens every time the app launches, and the default printer selection is never saved.

### Root cause
`apply_config()` in `WebGuideDialog.cpp` sets vendor/printer/filament data into `app_config` in memory, but neither the wizard dialog nor the caller (`GUI_App::run_wizard()`) ever called `app_config->save()` afterward. On next launch, the config loaded without printer data → `only_default_printers()` returned true → wizard reopened.

### Fix
Add `app_config->save()` in two places:
- `WebGuideDialog::run()` — after `apply_config()` completes (belt)
- `GUI_App::run_wizard()` — after `wizard.run()` returns successfully (suspenders)

## Test plan

- [ ] Delete `%APPDATA%\Cosmos3D` (or `%APPDATA%\OrcaSlicer`)
- [ ] Fresh install and launch — wizard opens (expected)
- [ ] Complete or cancel wizard
- [ ] Close and relaunch — wizard should NOT open again
- [ ] Cosmos3D X1 printer selected with 5000x10000mm build plate

🤖 Generated with [Claude Code](https://claude.com/claude-code)